### PR TITLE
Refactors: move handling events and simulation logic around, add blinking (reduce pallete to 7 bit), remove cursor update

### DIFF
--- a/emu.cpp
+++ b/emu.cpp
@@ -193,7 +193,7 @@ void handleInstruction(const uint32_t instruction) {
     } else if(type == C9_VGA_FUNCTION) {
         // TODO: implement
     } else if(type == C10_VGA_TEXT_BLINK) {
-        // TODO: implement
+        vga_C10_blink(bus() & blink_bit);
     } else if(type == C11_VGA_PIXEL_COLOR) {
         // TODO: implement
     } else if(type == C12_VGA_TEXT_WRITE) {
@@ -263,7 +263,7 @@ int main(int argc, char **argv) {
             const uint32_t instruction = program[programCounter++];
             handleInstruction(instruction);
         }
-	    display_update();
+        display_update();
     }
     display_teardown();
     return 0;

--- a/emu.cpp
+++ b/emu.cpp
@@ -254,16 +254,16 @@ int main(int argc, char **argv) {
     }
 
     bool quit = false;
-    int display_counter = 0;
 
     display_init();
     while(!quit) {
-        const uint32_t instruction = program[programCounter++];
-        handleInstruction(instruction);
-	    if (display_counter++ == instructions_per_display_update) {
-	        display_update();
-	        display_counter = 0;
-	    }
+        if(handle_events()) quit = true;
+
+        for(uint32_t i=0; i<instructions_per_display_update; i++) {
+            const uint32_t instruction = program[programCounter++];
+            handleInstruction(instruction);
+        }
+	    display_update();
     }
     display_teardown();
     return 0;

--- a/makefile
+++ b/makefile
@@ -2,8 +2,9 @@ CXX := g++
 CXXFLAGS := -std=c++11 -Wall -O2
 SDL2FLAGS=$(shell pkg-config sdl2 --cflags --libs)
 
-TEST_SOURCE := "prg/uart_test.pdc"
-TEST_SOURCE_BASE := "prg/jump_call_test.pdc"
+TEST_SOURCE := prg/uart_test.pdc
+TEST_SOURCE_BASE := prg/jump_call_test.pdc
+TEST_SOURCE_VGA := prg/vga_test.pdc
 BUILD_DIR := build
 
 all: $(BUILD_DIR)/emu.exe $(BUILD_DIR)/asm.exe
@@ -17,10 +18,19 @@ $(BUILD_DIR)/asm.exe: asm.cpp
 compile_flags.txt: makefile
 	echo '$(CXXFLAGS)' | tr ' ' '\n' > $@
 
-test: $(BUILD_DIR)/asm.exe $(BUILD_DIR)/emu.exe
+$(BUILD_DIR)/test.bin: $(TEST_SOURCE) ./$(BUILD_DIR)/asm.exe
 	cat $(TEST_SOURCE) | ./$(BUILD_DIR)/asm.exe > $(BUILD_DIR)/test.bin
+
+$(BUILD_DIR)/program.bin: $(TEST_SOURCE_BASE) ./$(BUILD_DIR)/asm.exe
 	cat $(TEST_SOURCE_BASE) | ./$(BUILD_DIR)/asm.exe > $(BUILD_DIR)/program.bin
-	./$(BUILD_DIR)/emu.exe $(BUILD_DIR)/test.bin
+
+$(BUILD_DIR)/test_vga.bin: $(TEST_SOURCE_VGA) ./$(BUILD_DIR)/asm.exe
+	cat $(TEST_SOURCE_VGA) | ./$(BUILD_DIR)/asm.exe > $(BUILD_DIR)/test_vga.bin
+
+test: $(BUILD_DIR)/asm.exe $(BUILD_DIR)/emu.exe $(BUILD_DIR)/test.bin $(BUILD_DIR)/program.bin $(BUILD_DIR)/test_vga.bin
+	./$(BUILD_DIR)/emu.exe $(BUILD_DIR)/test_vga.bin
+
+all: $(BUILD_DIR)/asm.exe $(BUILD_DIR)/emu.exe
 
 clean:
 	rm -rf $(BUILD_DIR)/*

--- a/prg/vga_test.pdc
+++ b/prg/vga_test.pdc
@@ -1,34 +1,59 @@
-C15 0x0000 ; topleft character
+A12 15 ; Literals
 
 loop_here:
+
+C15 0x0000 ; topleft character
 
 A10 0x0007 ; red on black
 C7         ; set colors
 C12 0x50    ; write P character
 
+C15 0x0001 ; topleft character+1
+
 A10 0x0038 ; green on black
 C7         ; set colors
 C12 0x44    ; write D character
 
-A10 0x00C9 ; brighter blue on black
+C15 0x0002 ; topleft character+2
+
+A10 0x0049 ; brighter blue on black
 C7         ; set colors
 C12 0x43   ; write C character
 
-A10 0x00ff ; white on black
+C15 0x0003 ; topleft character+3
+
+A10 0x007f ; white on black
 C7         ; set colors
 C12 0x33   ; write 3 character
 
-A10 0x00ff ; white on black
+C15 0x0004 ; topleft character+4
+
+A10 0x007f ; white on black
 C7         ; set colors
 C12 0x32   ; write 2 character
+
+C15 0x0005 ; topleft character+5
 
 A10 0x003F ; yellow on black
 C7         ; set colors
 C12 255    ; write special character
 
+C15 0x0006 ; topleft character+6
+
 A10 0x0000 ; black on black
 C7         ; set colors
 C12 32     ; write <space> character
 
+C15 0x0007 ; topleft character+7
+
+A10 0xff00 ; black on blinking white
+C7         ; set colors
+C12 1   ; write face
+
+C15 0x0008 ; topleft character+8
+
+A10 0x00ff ; blinking white on black
+C7         ; set colors
+C12 3   ; write face
 
 A5 loop_here

--- a/prg/vga_test.pdc
+++ b/prg/vga_test.pdc
@@ -1,4 +1,5 @@
 A12 15 ; Literals
+C10 0b1000000000000 ; Enable blink
 
 loop_here:
 
@@ -16,19 +17,19 @@ C12 0x44    ; write D character
 
 C15 0x0002 ; topleft character+2
 
-A10 0x0049 ; brighter blue on black
+A10 0x00C0 ; brighter blue on black (with blink)
 C7         ; set colors
 C12 0x43   ; write C character
 
 C15 0x0003 ; topleft character+3
 
-A10 0x007f ; white on black
+A10 0x00FF ; white on black
 C7         ; set colors
 C12 0x33   ; write 3 character
 
 C15 0x0004 ; topleft character+4
 
-A10 0x007f ; white on black
+A10 0x00FF ; white on black
 C7         ; set colors
 C12 0x32   ; write 2 character
 
@@ -46,7 +47,7 @@ C12 32     ; write <space> character
 
 C15 0x0007 ; topleft character+7
 
-A10 0xff00 ; black on blinking white
+A10 0x8700 ; black on blinking red
 C7         ; set colors
 C12 1   ; write face
 

--- a/vga.h
+++ b/vga.h
@@ -23,4 +23,7 @@ void vga_C7_text_color(uint8_t fg, uint8_t bg);
 void vga_C12_text_write(uint8_t c);
 void vga_C15_text_position(uint8_t row, uint8_t col);
 
+constexpr uint32_t blink_bit = 1<<12;
+void vga_C10_blink(bool enable);
+
 #endif // VGA_H

--- a/vga.h
+++ b/vga.h
@@ -12,6 +12,9 @@ void display_update();
 // shut it all down
 void display_teardown();
 
+// handle mouse/kbd/quit events, returns non zero on exit
+int handle_events();
+
 // ----------------------------------
 
 // implementation of PDC32 VGA opcodes


### PR DESCRIPTION
- Move SDL methods around, use RGB Texture instead of a surface (the pallete is looked up manually)
- Add blinking support (pallete now is 7 bits)
- Fix busyloop to use a 1 ms delay
- Add some easter eggs 😛 